### PR TITLE
Enable live billing summary updates and add UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,259 @@
+const services = [
+  {
+    id: "residential",
+    name: "Residential detox per diem",
+    code: "H0010",
+    rate: 0,
+    units: 7,
+    unitLabel: "days",
+    required: true,
+  },
+  {
+    id: "medical",
+    name: "Medical management",
+    code: "H0001",
+    rate: 180,
+    units: 3,
+    unitLabel: "visits",
+  },
+  {
+    id: "nursing",
+    name: "24/7 nursing monitoring",
+    code: "T1019",
+    rate: 95,
+    units: 7,
+    unitLabel: "days",
+  },
+  {
+    id: "therapy",
+    name: "Individual therapy",
+    code: "90837",
+    rate: 140,
+    units: 2,
+    unitLabel: "sessions",
+  },
+  {
+    id: "group",
+    name: "Group counseling",
+    code: "H0005",
+    rate: 45,
+    units: 5,
+    unitLabel: "sessions",
+  },
+  {
+    id: "lab",
+    name: "Toxicology screening",
+    code: "H0048",
+    rate: 120,
+    units: 2,
+    unitLabel: "tests",
+  },
+  {
+    id: "case",
+    name: "Case management",
+    code: "T1017",
+    rate: 85,
+    units: 2,
+    unitLabel: "hours",
+  },
+];
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const form = document.getElementById("billing-form");
+const servicesContainer = document.getElementById("services");
+const summary = document.getElementById("summary");
+const resetButton = document.getElementById("reset");
+
+const buildServices = () => {
+  servicesContainer.innerHTML = "";
+  services.forEach((service) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "service-item";
+
+    const toggle = document.createElement("input");
+    toggle.type = "checkbox";
+    toggle.name = `${service.id}-enabled`;
+    toggle.checked = service.required ?? false;
+
+    const info = document.createElement("div");
+    const title = document.createElement("strong");
+    title.textContent = service.name;
+    const meta = document.createElement("span");
+    meta.textContent = `Code ${service.code}`;
+    info.append(title, meta);
+
+    const rate = document.createElement("input");
+    rate.type = "number";
+    rate.name = `${service.id}-rate`;
+    rate.value = service.rate;
+    rate.min = "0";
+    rate.step = "0.01";
+    rate.title = "Rate per unit";
+
+    const units = document.createElement("input");
+    units.type = "number";
+    units.name = `${service.id}-units`;
+    units.value = service.units;
+    units.min = "0";
+    units.step = "1";
+    units.title = "Units";
+
+    const unitLabel = document.createElement("span");
+    unitLabel.textContent = service.unitLabel;
+
+    wrapper.append(toggle, info, rate, units, unitLabel);
+    servicesContainer.appendChild(wrapper);
+  });
+};
+
+const getNumber = (name) => {
+  const value = Number.parseFloat(form.elements[name]?.value ?? "0");
+  return Number.isFinite(value) ? value : 0;
+};
+
+const getText = (name) => form.elements[name]?.value ?? "";
+
+const renderSummary = ({
+  totalAllowed,
+  adjustedAllowed,
+  allowedFactor,
+  deductibleApplied,
+  coinsuranceAmount,
+  copayAmount,
+  patientResponsibility,
+  payerResponsibility,
+  oopRemaining,
+  billables,
+}) => {
+  summary.classList.remove("empty");
+  summary.innerHTML = `
+    <div class="summary-grid">
+      <div class="summary-card">
+        <h4>Policy snapshot</h4>
+        <p><strong>${getText("clientName") || "Client"}</strong></p>
+        <p>${getText("planType")} • ${getText("networkStatus") === "in" ? "In-network" : "Out-of-network"}</p>
+        <p>${getText("levelOfCare")}</p>
+        <span class="tag">Prior auth: ${getText("priorAuth")}</span>
+      </div>
+      <div class="summary-card">
+        <h4>Allowed charges</h4>
+        <p>Base allowed: ${currency.format(totalAllowed)}</p>
+        <p>Network factor: ${allowedFactor.toFixed(2)}x</p>
+        <p><strong>${currency.format(adjustedAllowed)}</strong></p>
+      </div>
+      <div class="summary-card">
+        <h4>Patient responsibility</h4>
+        <p>Deductible: ${currency.format(deductibleApplied)}</p>
+        <p>Coinsurance: ${currency.format(coinsuranceAmount)}</p>
+        <p>Copays: ${currency.format(copayAmount)}</p>
+        <p><strong>${currency.format(patientResponsibility)}</strong></p>
+      </div>
+      <div class="summary-card">
+        <h4>Payer responsibility</h4>
+        <p><strong>${currency.format(payerResponsibility)}</strong></p>
+        <p>OOP remaining cap: ${currency.format(oopRemaining)}</p>
+      </div>
+    </div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Service</th>
+          <th>Code</th>
+          <th>Units</th>
+          <th>Rate</th>
+          <th>Allowed</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${billables
+          .map(
+            (service) => `
+          <tr>
+            <td>${service.name}</td>
+            <td>${service.code}</td>
+            <td>${service.units}</td>
+            <td>${currency.format(service.rate)}</td>
+            <td>${currency.format(service.rate * service.units)}</td>
+          </tr>
+        `,
+          )
+          .join("")}
+      </tbody>
+    </table>
+  `;
+};
+
+const calculateBilling = () => {
+  const days = Math.max(1, getNumber("days"));
+  const perDiem = Math.max(0, getNumber("perDiem"));
+  const allowedFactor = Math.max(0, getNumber("allowedFactor"));
+  const deductible = Math.max(0, getNumber("deductible"));
+  const oopRemaining = Math.max(0, getNumber("oop"));
+  const coinsuranceRate = Math.min(100, Math.max(0, getNumber("coinsurance"))) / 100;
+  const copayPerDay = Math.max(0, getNumber("copay"));
+
+  const selectedServices = services.map((service) => {
+    const enabled = form.elements[`${service.id}-enabled`]?.checked ?? false;
+    const rate = Math.max(0, getNumber(`${service.id}-rate`));
+    const units = Math.max(0, getNumber(`${service.id}-units`));
+    return {
+      ...service,
+      enabled,
+      rate: service.id === "residential" ? perDiem : rate,
+      units: service.id === "residential" ? days : units,
+    };
+  });
+
+  const billables = selectedServices.filter((service) => service.enabled);
+  const totalAllowed = billables.reduce(
+    (sum, service) => sum + service.rate * service.units,
+    0,
+  );
+  const adjustedAllowed = totalAllowed * allowedFactor;
+
+  const deductibleApplied = Math.min(deductible, adjustedAllowed);
+  const afterDeductible = Math.max(0, adjustedAllowed - deductibleApplied);
+  const coinsuranceAmount = afterDeductible * coinsuranceRate;
+  const copayAmount = copayPerDay * days;
+  let patientResponsibility = deductibleApplied + coinsuranceAmount + copayAmount;
+
+  if (patientResponsibility > oopRemaining) {
+    patientResponsibility = oopRemaining;
+  }
+
+  const payerResponsibility = Math.max(0, adjustedAllowed - patientResponsibility);
+
+  renderSummary({
+    totalAllowed,
+    adjustedAllowed,
+    allowedFactor,
+    deductibleApplied,
+    coinsuranceAmount,
+    copayAmount,
+    patientResponsibility,
+    payerResponsibility,
+    oopRemaining,
+    billables,
+  });
+};
+
+const analyzeBilling = (event) => {
+  event.preventDefault();
+  calculateBilling();
+};
+
+const resetForm = () => {
+  form.reset();
+  buildServices();
+  calculateBilling();
+};
+
+buildServices();
+calculateBilling();
+form.addEventListener("submit", analyzeBilling);
+form.addEventListener("input", calculateBilling);
+resetButton.addEventListener("click", resetForm);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Detox Residential Billing Analyzer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div>
+      <p class="eyebrow">Internal Billing Tool</p>
+      <h1>Detox Residential Treatment Billing Analyzer</h1>
+      <p class="subhead">
+        Estimate billable services, payer responsibility, and patient responsibility based on policy details for
+        detox residential treatment.
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Client &amp; Policy Details</h2>
+      <form id="billing-form">
+        <div class="grid">
+          <label>
+            Client name
+            <input type="text" name="clientName" placeholder="Jordan Smith" />
+          </label>
+          <label>
+            Member ID
+            <input type="text" name="memberId" placeholder="ABC123456" />
+          </label>
+          <label>
+            Plan type
+            <select name="planType">
+              <option>PPO</option>
+              <option>HMO</option>
+              <option>EPO</option>
+              <option>Medicaid MCO</option>
+              <option>Commercial</option>
+            </select>
+          </label>
+          <label>
+            Network status
+            <select name="networkStatus">
+              <option value="in">In-network</option>
+              <option value="out">Out-of-network</option>
+            </select>
+          </label>
+          <label>
+            Detox level of care
+            <select name="levelOfCare">
+              <option>ASAM 3.7-WM (Medically monitored)</option>
+              <option>ASAM 3.2-WM (Clinically managed)</option>
+              <option>ASAM 3.5 (Residential)</option>
+            </select>
+          </label>
+          <label>
+            Days authorized
+            <input type="number" name="days" value="7" min="1" />
+          </label>
+          <label>
+            Per diem rate (allowed)
+            <input type="number" name="perDiem" value="850" min="0" step="0.01" />
+          </label>
+          <label>
+            Network allowed factor
+            <input type="number" name="allowedFactor" value="1" min="0" step="0.01" />
+          </label>
+          <label>
+            Prior authorization
+            <select name="priorAuth">
+              <option>Verified</option>
+              <option>Pending</option>
+              <option>Not required</option>
+            </select>
+          </label>
+        </div>
+
+        <h3>Cost Share</h3>
+        <div class="grid">
+          <label>
+            Deductible remaining
+            <input type="number" name="deductible" value="1000" min="0" step="0.01" />
+          </label>
+          <label>
+            Out-of-pocket remaining
+            <input type="number" name="oop" value="2500" min="0" step="0.01" />
+          </label>
+          <label>
+            Coinsurance % (patient)
+            <input type="number" name="coinsurance" value="20" min="0" max="100" step="1" />
+          </label>
+          <label>
+            Copay per day
+            <input type="number" name="copay" value="40" min="0" step="0.01" />
+          </label>
+        </div>
+
+        <h3>Billable Services</h3>
+        <p class="help">Toggle the services you deliver and adjust units to estimate billable totals.</p>
+        <div id="services" class="services"></div>
+
+        <div class="actions">
+          <button type="submit">Analyze Billing</button>
+          <button type="button" id="reset">Reset</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card results">
+      <h2>Billing Summary</h2>
+      <div id="summary" class="summary empty">
+        <p>Complete the form and click “Analyze Billing” to see billable details.</p>
+      </div>
+    </section>
+
+    <section class="card disclaimer">
+      <h2>Compliance Notes</h2>
+      <ul>
+        <li>Confirm benefits with the payer and verify authorization requirements before billing.</li>
+        <li>Rates shown are estimates and should be reconciled with contract allowed amounts.</li>
+        <li>Use accurate clinical documentation and medical necessity criteria for all billed services.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <p>Internal use only. Not a guarantee of payment.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,218 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: #f6f6f9;
+  color: #162033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.hero {
+  padding: 3rem 7vw 2rem;
+  background: linear-gradient(120deg, #0c2340, #1d4f91);
+  color: #f8fbff;
+}
+
+.hero h1 {
+  margin: 0.4rem 0 0.6rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+.subhead {
+  max-width: 62ch;
+  line-height: 1.5;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem 7vw 3rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: #28364f;
+}
+
+input,
+select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #d3d9e5;
+  font-size: 0.95rem;
+  background: #fdfdff;
+}
+
+input:focus,
+select:focus {
+  outline: 2px solid #699bf7;
+  border-color: transparent;
+}
+
+.help {
+  margin-top: -0.5rem;
+  color: #536079;
+}
+
+.services {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.service-item {
+  border: 1px solid #e2e8f0;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.service-item input[type="number"] {
+  width: 90px;
+}
+
+.service-item span {
+  font-size: 0.85rem;
+  color: #4a5568;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+}
+
+button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: #1d4f91;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button#reset {
+  background: #eef2f7;
+  color: #1d4f91;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(29, 79, 145, 0.18);
+}
+
+.results .summary {
+  border: 1px dashed #cbd5e1;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.summary.empty {
+  color: #64748b;
+  font-style: italic;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  background: #f8fafc;
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.summary-card h4 {
+  margin: 0 0 0.25rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 0.6rem;
+  border-bottom: 1px solid #e2e8f0;
+  font-size: 0.9rem;
+}
+
+.table th {
+  background: #f1f5f9;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.disclaimer li {
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 720px) {
+  .actions {
+    flex-direction: column;
+  }
+
+  .service-item {
+    grid-template-columns: auto 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the detox residential billing tool usable immediately by showing an interactive summary without requiring an explicit "Analyze" click.
- Provide a small single-page UI to collect client/policy inputs and selectable billable services for quick internal estimates.
- Include reasonable defaults for common services and responsive styling so the tool works on different screen sizes.

### Description
- Add `index.html` with the form and results containers, `styles.css` for layout and responsive styling, and `app.js` implementing the billing logic and UI wiring.
- Define default service entries (per-diem residential plus ancillary services) and form inputs for days, per diem, allowed factor, deductible, coinsurance, copays, and OOP remaining.
- Implement calculation logic in `app.js` that aggregates selected services, applies the network `allowedFactor`, applies `deductible`, computes `coinsurance`, adds `copay` charges, enforces an OOP cap, and computes payer responsibility, then renders summary cards and a billable line-item table.
- Render the summary on load and update it automatically on form `input` events, while keeping the `Reset` action to rebuild services and refresh calculations.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that loaded `http://127.0.0.1:8000/` and captured a screenshot saved to `artifacts/billing-tool-live.png`, which completed successfully.
- No automated unit tests were added for the static HTML/CSS/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967674d79988322bbcfc0d39858aa30)